### PR TITLE
[Sandstorm port] Placing screwdrivers and wrenches on tables

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -170,13 +170,13 @@
 
 /obj/structure/table/attackby(obj/item/I, mob/user, params)
 	if(!(flags_1 & NODECONSTRUCT_1))
-		if(istype(I, /obj/item/screwdriver) && deconstruction_ready)
+		if(istype(I, /obj/item/screwdriver) && deconstruction_ready && !(user.a_intent == INTENT_HELP))
 			to_chat(user, "<span class='notice'>You start disassembling [src]...</span>")
 			if(I.use_tool(src, user, 20, volume=50))
 				deconstruct(TRUE)
 			return
 
-		if(istype(I, /obj/item/wrench) && deconstruction_ready)
+		if(istype(I, /obj/item/wrench) && deconstruction_ready && !(user.a_intent == INTENT_HELP))
 			to_chat(user, "<span class='notice'>You start deconstructing [src]...</span>")
 			if(I.use_tool(src, user, 40, volume=50))
 				playsound(src.loc, 'sound/items/deconstruct.ogg', 50, 1)


### PR DESCRIPTION
## About The Pull Request

Allows you to put your tools on the tables.

## Why It's Good For The Game

I DIDNT MEAN TO BREAK THE TABLE NOOOOOOOOOOOOO.

## Changelog
:cl:
refactor: By being on help intent, you can place screwdrivers and wrenchs on tables.
/:cl: