### PR TITLE
Time-lock for Warden

### DIFF
--- a/code/modules/jobs/job_types/warden.dm
+++ b/code/modules/jobs/job_types/warden.dm
@@ -12,6 +12,7 @@
 	minimal_player_age = 7
 	exp_requirements = 300
 	exp_type = EXP_TYPE_CREW
+	exp_type_department = EXP_TYPE_SECURITY
 	considered_combat_role = TRUE
 
 	outfit = /datum/outfit/job/warden


### PR DESCRIPTION
## About The Pull Request

An attempt at locking Warden behind playtime requirement system.

## Why It's Good For The Game

If it works, we should no longer have the infamous 'Warden suicide speedruns'.

## Changelog
:cl:
code: Added exp_type_department = EXP_TYPE_SECURITY to Warden.dm file
/:cl: