### PR TITLE
Bluespace locker fixes

### DIFF
--- a/_maps/map_files/generic/CentCom_nostration.dmm
+++ b/_maps/map_files/generic/CentCom_nostration.dmm
@@ -7363,9 +7363,7 @@
 /area/syndicate_mothership)
 "qL" = (
 /obj/structure/closet/bluespace/internal,
-/turf/closed/indestructible/abductor{
-	icon_state = "alien22"
-	},
+/turf/open/floor/plasteel/dark,
 /area/bluespace_locker)
 "qQ" = (
 /obj/machinery/door/airlock/centcom{
@@ -24791,8 +24789,8 @@ aa
 aa
 aa
 aa
+rj
 qL
-GN
 GN
 PW
 GN

--- a/code/datums/components/stationloving.dm
+++ b/code/datums/components/stationloving.dm
@@ -56,8 +56,8 @@
 	if (!T)
 		return FALSE
 	var/area/A = T.loc
-    if(istype(A, GLOB.station_loving_blacklist)) // Obviously terrible, just for test merging
-        return FALSE
+	if(istype(A, GLOB.station_loving_blacklist)) // Nostra change
+		return FALSE
 	if (is_station_level(T.z) || is_centcom_level(T.z))
 		return TRUE
 	if (is_reserved_level(T.z))

--- a/code/datums/components/stationloving.dm
+++ b/code/datums/components/stationloving.dm
@@ -56,8 +56,8 @@
 	if (!T)
 		return FALSE
 	var/area/A = T.loc
-	if(istype(A, /area/fabric_of_reality)) // Obviously terrible, just for test merging
-		return FALSE
+    if(istype(A, GLOB.station_loving_blacklist)) // Obviously terrible, just for test merging
+        return FALSE
 	if (is_station_level(T.z) || is_centcom_level(T.z))
 		return TRUE
 	if (is_reserved_level(T.z))

--- a/modular_nostration/code/controllers/subsystem/bluespace_locker.dm
+++ b/modular_nostration/code/controllers/subsystem/bluespace_locker.dm
@@ -4,6 +4,8 @@ SUBSYSTEM_DEF(bluespace_locker)
 	var/obj/structure/closet/bluespace/internal/internal_locker = null
 	var/obj/structure/closet/bluespace/external/external_locker = null
 
+GLOBAL_LIST_INIT(station_loving_blacklist, list(/area/fabric_of_reality, /area/bluespace_locker))
+
 /datum/controller/subsystem/bluespace_locker/Initialize()
 	bluespaceify_random_locker()
 	if(external_locker)


### PR DESCRIPTION
## About The Pull Request

Bluespace locker fixes

## Changelog
:cl:
tweak: Bluespace locker area doesn't allow nuke disk anymore
fix: Moved bluespace locker location one tile lower
/:cl: