### PR TITLE
Some small changes to make the particle defender more in line with other shotguns. 

### DIFF
--- a/modular_citadel/code/modules/projectiles/guns/pumpenergy.dm
+++ b/modular_citadel/code/modules/projectiles/guns/pumpenergy.dm
@@ -153,7 +153,7 @@
 
 /obj/item/ammo_casing/energy/laser/pump
 	projectile_type = /obj/item/projectile/beam/pump
-	e_cost = 350
+	e_cost = 200
 	select_name = "kill"
 	pellets = 6
 	variance = 15
@@ -163,7 +163,7 @@
 	projectile_type = /obj/item/projectile/energy/disabler/pump
 	select_name = "disable"
 	fire_sound = 'sound/weapons/LaserSlugv3.ogg'
-	e_cost = 150
+	e_cost = 120
 	pellets = 6
 	variance = 20
 
@@ -182,12 +182,12 @@
 	icon_state = "disablerslug"
 
 /obj/item/projectile/beam/pump
-	damage = 9
+	damage = 10
 	range = 6
 
 /obj/item/projectile/energy/disabler/pump
 	name = "disabling blast"
 	icon_state = "disablerslug"
 	color = null
-	stamina = 13
+	stamina = 15
 	range = 6


### PR DESCRIPTION
## About The Pull Request

This increases the number of shots the particle defender can fire before needing to recharge as well as slightly increasing the damage to be more in line with rubbershot and buckshot for both modes.
edit: Disable mode allows for 10 shots with 90 stamina damage if all beams hit. Originally 8 shots with 78.
edit: Kill mode allows for 6 shots with 60 burn damage if all beams hit. Originally 3 shots with 54.

## Why It's Good For The Game

This makes the warden's particle defender more on par with other shotguns, increasing margin for error and making for a far scarier weapon to be up against.

## A Port?

<!-- Some small changes to make the particle defender more in line with other shotguns.  - https://github.com/Skyrat-SS13/Skyrat13/pull/3472 -->

## Changelog
:cl:
balance: adjusts number of shots and damage the particle defender has.
/:cl:
