### PR TITLE
Update jobs.dm

### DIFF
--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -5,7 +5,8 @@ GLOBAL_LIST_INIT(command_positions, list(
 	"Chief Engineer",
 	"Research Director",
 	"Chief Medical Officer",
-	"Quartermaster"))
+	"Quartermaster",
+	"Warden"))
 
 GLOBAL_LIST_INIT(engineering_positions, list(
 	"Chief Engineer",


### PR DESCRIPTION
Added Warden to command roles in code, purely to make it playtime locked.

## About The Pull Request

Warden added to Command roles in code.

## Why It's Good For The Game

Because it SHOULD apply a playtime lock for this role, so no more Warden any% suicide speedruns.

## Changelog
:cl:
tweak: "Warden" added to command_positions
/:cl: